### PR TITLE
Fix sample java code so that it compiles

### DIFF
--- a/chapter10.rst
+++ b/chapter10.rst
@@ -233,7 +233,7 @@ Let’s take a look at the same example from above and apply the loosely coupled
 	    }
 
 
-	   public static Object createObject(Object interfaceType, String moduleName){
+	   public Object createObject(Object interfaceType, String moduleName){
 	       Object javaInt = null;
 	       PythonInterpreter interpreter = new PythonInterpreter();
 	       interpreter.exec("from " + moduleName + " import " + moduleName);


### PR DESCRIPTION
createObject is accessed as if it were an instance method in the sample java code. This converts it to an instance method.

It makes sense for it to be an instance method anyway considering it's a factory object.