### PR TITLE
Repair index. Add README, conf.py, requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# The Jython Book
+
+This is an open reference book on the Jython language, an implementation of Python implemented in, and highly interoperable with, Java. It is maintained as a reference to the current version of Jython (perhaps with a touch of lag).
+
+
+## Project
+
+This book is formatted for and available at https://jython.readthedocs.io/en/latest/
+
+
+## Version History
+
+
+| Jython Version | Book version | Book citation |
+| -------------- | ------------ | ---------| 
+| Jython 2.5     | 1.0          | Juneau, J., Baker, J., Wierzbicki, F., Muoz, L. S., Ng, V., Ng, A., & Baker, D. L. (2010). The definitive guide to Jython: Python for the Java platform. Apress. |
+ 
+
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This is an open reference book on the Jython language, an implementation of Pyth
 
 This book is formatted for and available at https://jython.readthedocs.io/en/latest/
 
+## License and Contributions
+
+This book is licensed under CC-BY-SA http://creativecommons.org/licenses/by-sa/3.0/ . Contributions in the form of pull requests are welcome, and are covered by the same license under the "inbound=outbound" part of the github terms of service https://help.github.com/en/articles/github-terms-of-service#6-contributions-under-repository-license . More detail on the open book license can be found in the book index and preamble (index.rst).
+
+
 
 ## Version History
 

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+
+extensions = []
+templates_path = ['/home/docs/checkouts/readthedocs.org/readthedocs/templates/sphinx', 'templates', '_templates', '.templates']
+source_suffix = ['.rst']		
+master_doc = 'index'
+project = u'jython'
+copyright = u'2016'
+version = 'latest'
+release = 'latest'
+exclude_patterns = ['_build','sandbox']
+pygments_style = 'sphinx'
+htmlhelp_basename = 'jython'
+html_theme = 'sphinx_rtd_theme'
+file_insertion_enabled = False
+latex_documents = [
+  ('index', 'jython.tex', u'jython Documentation',
+   u'', 'manual'),
+]
+

--- a/conf.py
+++ b/conf.py
@@ -2,7 +2,7 @@
 
 
 extensions = []
-templates_path = ['/home/docs/checkouts/readthedocs.org/readthedocs/templates/sphinx', 'templates', '_templates', '.templates']
+templates_path = ['_templates']
 source_suffix = ['.rst']		
 master_doc = 'index'
 project = u'jython'

--- a/index.rst
+++ b/index.rst
@@ -15,7 +15,7 @@ Python for the Java Platform
     Leo Soto,
     Frank Wierzbicki
 
-:Version: 0.9 of 10/18/2009
+:Version: 1.0 of 10/18/2009
 
 This book is presented in open source and licensed through Creative Commons 3.0.
 You are free to copy, distribute, transmit, and/or adapt the work.  This license
@@ -46,7 +46,7 @@ Notice:  For any reuse or distribution, you must make clear to the others
 the license terms of this work.  The best way to do this is with a direct
 link to this page:  http://creativecommons.org/licenses/by-sa/3.0/
 
-To be printed by Apress Fall 2009 -- http://www.apress.com/book/view/9781430225270
+First edition printed by Apress Fall 2009 -- http://www.apress.com/book/view/9781430225270
 
  ISBN10: 1-4302-2527-0
 
@@ -63,11 +63,10 @@ Part I:  Jython Basics:  Learning the Language
 .. toctree::
    :maxdepth: 2
    
-   intro.rst
+   chapter1.rst
    chapter2.rst
    chapter3.rst
    chapter4.rst
-   chapter9.rst
    chapter5.rst
    chapter6.rst
    chapter7.rst
@@ -79,6 +78,7 @@ Part II: Using the Language
    :maxdepth: 2
 
    chapter8.rst
+   chapter9.rst
    chapter10.rst
    chapter11.rst
    chapter12.rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+Pygments==2.2.0 
+setuptools==28.8.0 
+docutils==0.13.1 
+mock==1.0.1 
+alabaster>=0.7,<0.8,!=0.7.5 
+commonmark==0.5.4 
+sphinx==1.5.3 
+sphinx-rtd-theme<0.3 
+readthedocs-sphinx-ext<0.6
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
-Pygments==2.2.0 
-setuptools==28.8.0 
-docutils==0.13.1 
-mock==1.0.1 
-alabaster>=0.7,<0.8,!=0.7.5 
-commonmark==0.5.4 
-sphinx==1.5.3 
-sphinx-rtd-theme<0.3 
-readthedocs-sphinx-ext<0.6
+sphinx
+sphinx-rtd-theme
 


### PR DESCRIPTION
Chapter 1 was missing and Chapter 9 misplaced. 

`conf.py` is a requirement for Sphinx, but some weird fallback in readthedocs was making it work
anyway.
https://stackoverflow.com/questions/55840739/how-does-readthedocs-generate-sphinx-html-from-rst-without-a-conf-py

The `conf.py` and `requirements.txt` was taken from the last build log on readthedocs. Markdown dependencies were removed from both to make it easier to test locally, and since it isn't used in the book.

If this patch works, it would be good to tag the resulting version jython_book_1_0 before continuing with further patches. I think it would be worth refreshing the book to reflect 2.7, rather than 2.5, and as the most consistent and canonical documentation.
