### PR TITLE
chapter11: Support both Python 2 and Python 3

### DIFF
--- a/src/chapter11/LearningPyDev/src/hello/console.py
+++ b/src/chapter11/LearningPyDev/src/hello/console.py
@@ -1,5 +1,6 @@
+from __future__ import print_function
 from hello import register_ui
 
 @register_ui('console')
 def print_message(msg):
-    print msg
+    print(msg)

--- a/src/chapter11/LearningPyDev/src/hello/tests.py
+++ b/src/chapter11/LearningPyDev/src/hello/tests.py
@@ -1,3 +1,4 @@
+from importlib import reload
 import unittest
 import hello
 
@@ -5,29 +6,29 @@ class UIMock(object):
     def __init__(self):
         self.msgs = []
     def __call__(self, msg):
-        self.msgs.append(msg)    
+        self.msgs.append(msg)
 
 class TestUIs(unittest.TestCase):
-    def setUp(self):        
+    def setUp(self):
         global hello
         hello = reload(hello)
         self.foo = UIMock()
         self.bar = UIMock()
-        hello.register_ui('foo')(self.foo)    
+        hello.register_ui('foo')(self.foo)
         hello.register_ui('bar')(self.bar)
         hello.message('foo', "message using the foo UI")
         hello.message('foo', "another message using foo")
         hello.message('bar', "message using the bar UI")
-    
+
     def testBarMessages(self):
-        self.assertEqual(["message using the bar UI"], self.bar.msgs) 
-    
+        self.assertEqual(["message using the bar UI"], self.bar.msgs)
+
     def testFooMessages(self):
-        self.assertEqual(["message using the foo UI", 
+        self.assertEqual(["message using the foo UI",
                           "another message using foo"],
-                          self.foo.msgs)    
+                          self.foo.msgs)
     def testNonExistentUI(self):
-        self.assertRaises(hello.UINotSupportedExeption, 
+        self.assertRaises(hello.UINotSupportedExeption,
                           hello.message, 'non-existent-ui', 'msg')
 
     def testListUIs(self):

--- a/src/chapter11/LearningPyDev/src/main.py
+++ b/src/chapter11/LearningPyDev/src/main.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import hello, hello.console, hello.window, hello.speech
 from optparse import OptionParser
@@ -11,16 +12,16 @@ def main(args):
                       help="Sets the language to use")
     options, args = parser.parse_args(args)
     if len(args) < 2:        
-        print "Sorry, I can't greet you if you don't say your name"
+        print("Sorry, I can't greet you if you don't say your name")
         return 1    
     try:
         hello.greet(args[1], options.lang, options.ui)        
     except hello.LanguageNotSupportedException:
-        print "Sorry, I don't speak '%s'" % options.lang
+        print("Sorry, I don't speak '%s'" % options.lang)
         return 1
     except hello.UINotSupportedExeption:
-        print "Invalid UI name\n"    
-        print "Valid UIs:\n\n" + "\n".join(' * ' + ui for ui in hello.list_uis())
+        print("Invalid UI name\n")    
+        print("Valid UIs:\n\n" + "\n".join(' * ' + ui for ui in hello.list_uis()))
         return 1
     
 if __name__ == "__main__":


### PR DESCRIPTION
Make the chapter 11 code syntax compatible with both Python 2 and Python 3.

$ __[futurize](https://python-future.org/automatic_conversion.html) -f libfuturize.fixes.fix_print_with_import -w src/chapter11__