### PR TITLE
chapter14: Support both Python 2 and Python 3

### DIFF
--- a/src/chapter14/helloworld/scripts/client.py
+++ b/src/chapter14/helloworld/scripts/client.py
@@ -8,6 +8,7 @@ supports durable message subscribers. Obtain a copy from here :
 
     http://bitbucket.org/crankycoder/python-stomp/overview/
 """
+from __future__ import print_function
 import sys
 import stomp
 import socket
@@ -101,5 +102,5 @@ if __name__ == '__main__':
     else:
         msg_iter = stomper.recv()
         while True:
-            print "Received: ", msg_iter.next()
+            print("Received: ", msg_iter.next())
 

--- a/src/chapter14/helloworld/scripts/jms_recv.py
+++ b/src/chapter14/helloworld/scripts/jms_recv.py
@@ -1,6 +1,7 @@
 """
 This is a standalone client that listens messages from JMS 
 """
+from __future__ import print_function
 from java.io import BufferedReader, InputStreamReader
 from java.lang import System
 from java.util import Properties
@@ -34,6 +35,6 @@ class TopicListener(MessageListener):
         # tconnection.close()
 
     def onMessage(self, message):
-        print message.getText()
+        print(message.getText())
 
 TopicListener().go()

--- a/src/chapter14/helloworld/scripts/jms_send.py
+++ b/src/chapter14/helloworld/scripts/jms_send.py
@@ -1,6 +1,7 @@
 """
 This is a standalone client that listens messages from JMS 
 """
+from __future__ import print_function
 from java.io import BufferedReader, InputStreamReader
 from java.lang import System
 from java.util import Properties
@@ -34,6 +35,6 @@ class TopicListener(MessageListener):
         # tconnection.close()
 
     def onMessage(self, message):
-        print message.getText()
+        print(message.getText())
 
 TopicListener().go()


### PR DESCRIPTION
Make the chapter 14 code syntax compatible with both Python 2 and Python 3.

$ __[futurize](https://python-future.org/automatic_conversion.html) -f libfuturize.fixes.fix_print_with_import -w src/chapter14__